### PR TITLE
Use `Include` in `formFor`

### DIFF
--- a/Web/Controller/Posts.hs
+++ b/Web/Controller/Posts.hs
@@ -15,7 +15,8 @@ instance Controller PostsController where
         render IndexView { .. }
 
     action NewPostAction = do
-        let post = newRecord
+        let post = newRecord @Post
+        post <- post |> fetchRelated #comments
         render NewView { .. }
 
     action ShowPostAction { postId } = do
@@ -44,7 +45,9 @@ instance Controller PostsController where
         post
             |> buildPost
             |> ifValid \case
-                Left post -> render NewView { .. } 
+                Left post -> do
+                    post <- post |> fetchRelated #comments
+                    render NewView { .. }
                 Right post -> do
                     post <- post |> createRecord
                     setSuccessMessage "Post created"

--- a/Web/Controller/Posts.hs
+++ b/Web/Controller/Posts.hs
@@ -27,6 +27,7 @@ instance Controller PostsController where
 
     action EditPostAction { postId } = do
         post <- fetch postId
+            >>= fetchRelated #comments
         render EditView { .. }
 
     action UpdatePostAction { postId } = do
@@ -34,9 +35,12 @@ instance Controller PostsController where
         post
             |> buildPost
             |> ifValid \case
-                Left post -> render EditView { .. }
+                Left post -> do
+                    post <- post |> fetchRelated #comments
+                    render EditView { .. }
                 Right post -> do
                     post <- post |> updateRecord
+                        >>= fetchRelated #comments
                     setSuccessMessage "Post updated"
                     redirectTo EditPostAction { .. }
 

--- a/Web/Controller/Posts.hs
+++ b/Web/Controller/Posts.hs
@@ -68,6 +68,7 @@ buildPost post = post
     |> validateField #title nonEmpty
     |> validateField #body nonEmpty
     |> validateField #body isMarkdown
+    |> attachFailure #comments "Invalid comments!"
 
 isMarkdown :: Text -> ValidatorResult
 isMarkdown text =

--- a/Web/View/Posts/Edit.hs
+++ b/Web/View/Posts/Edit.hs
@@ -1,7 +1,7 @@
 module Web.View.Posts.Edit where
 import Web.View.Prelude
 
-data EditView = EditView { post :: Post }
+data EditView = EditView { post :: Include "comments" Post }
 
 instance View EditView where
     html EditView { .. } = [hsx|
@@ -15,9 +15,12 @@ instance View EditView where
         {renderForm post}
     |]
 
-renderForm :: Post -> Html
+renderForm :: Include "comments" Post -> Html
 renderForm post = formFor post [hsx|
     {textField #title}
     {(textareaField #body) { helpText = "You can use Markdown here"} }
+
+    {textField #comments}
+
     {submitButton}
 |]

--- a/Web/View/Posts/New.hs
+++ b/Web/View/Posts/New.hs
@@ -1,7 +1,7 @@
 module Web.View.Posts.New where
 import Web.View.Prelude
 
-data NewView = NewView { post :: Post }
+data NewView = NewView { post :: Include "comments" Post }
 
 instance View NewView where
     html NewView { .. } = [hsx|
@@ -15,7 +15,7 @@ instance View NewView where
         {renderForm post}
     |]
 
-renderForm :: Post -> Html
+renderForm :: Include "comments" Post -> Html
 renderForm post = formFor post [hsx|
     {textField #title}
     {(textareaField #body) { helpText = "You can use Markdown here"} }

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
 let
     ihp = builtins.fetchGit {
         url = "https://github.com/digitallyinduced/ihp.git";
-        ref = "refs/tags/v0.18.0";
+        # ref = "refs/tags/v0.18.0";
+        rev = "df1832754470dcc6538b80580dacfeabdcf61556";
     };
     haskellEnv = import "${ihp}/NixSupport/default.nix" {
         ihp = ihp;

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 let
     ihp = builtins.fetchGit {
         url = "https://github.com/digitallyinduced/ihp.git";
-        ref = "refs/tags/v0.16.0";
+        ref = "refs/tags/v0.18.0";
     };
     haskellEnv = import "${ihp}/NixSupport/default.nix" {
         ihp = ihp;


### PR DESCRIPTION
I'm trying to embed related entities in `formFor`, with some modest progress.

 With the current code we are able to call `{textField #comments}` and be presented with the `Include`d comment ref (currently a single ref).

Furthermore, we are able to `attachFailure` to that connected field.

![image](https://user-images.githubusercontent.com/125707/152420795-39b2f0e9-fb9f-424a-be65-59aed5acc8d9.png)

Next, when I was naively trying to 

```diff
buildPost post = post
-   |> fill @["title","body"]
+   |> fill @["title","body", "comments"] 
```

We get

![image](https://user-images.githubusercontent.com/125707/152421070-15600a07-f978-4816-9ebf-61f6a0a6b6ed.png)

@mpscholten  do you think it's a valid path? Any pointers on how to proceed?